### PR TITLE
[svelte] fix svelte running directions

### DIFF
--- a/svelte-app/README.md
+++ b/svelte-app/README.md
@@ -30,7 +30,7 @@ This project was created to help represent a fundamental app written with Svelte
 1. Run the app
 
    ```bash
-   npm run quick
+   npm run dev
    ```
 
 


### PR DESCRIPTION
This change fixes the directions to run the svelte app, which referenced a `quick` script in package.json that didn't exist.