### PR TITLE
added routes.json to all apps

### DIFF
--- a/angular-app/src/assets/routes.json
+++ b/angular-app/src/assets/routes.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    {
+      "route": "/*",
+      "serve": "/index.html",
+      "statusCode": 200
+    }
+  ]
+}

--- a/react-app/public/routes.json
+++ b/react-app/public/routes.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    {
+      "route": "/*",
+      "serve": "/index.html",
+      "statusCode": 200
+    }
+  ]
+}

--- a/svelte-app/public/routes.json
+++ b/svelte-app/public/routes.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    {
+      "route": "/*",
+      "serve": "/index.html",
+      "statusCode": 200
+    }
+  ]
+}

--- a/vue-app/public/routes.json
+++ b/vue-app/public/routes.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    {
+      "route": "/*",
+      "serve": "/index.html",
+      "statusCode": 200
+    }
+  ]
+}


### PR DESCRIPTION
Added the routes.json file to all 4 of the web framework apps. The Learn module now assumes this file exists and explains it, instead of asking the learner to add it. This is part of the reduction of units in the Learn module found [here](https://github.com/MicrosoftDocs/learn-pr/pull/12984)

Do not merge until the PR in Learn has been merged and published


cc @nickwalkmsft