### PR TITLE
Update sample app links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ The shopping theme is used throughout the app.
 
 The apps written in the following JavaScript frameworks/libraries:
 
-| folder          | Description                                                                                                 |
-| --------------- | ----------------------------------------------------------------------------------------------------------- |
-| **angular-app** | [Sample Angular app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/blob/master/angular-app)         |
-| **api-starter** | [Sample Azure Functions app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/blob/master/api-starter) |
-| **react-app**   | [Sample React app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/blob/master/react-app)             |
-| **svelte-app**  | [Sample Svelte app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/blob/master/svelte-app)           |
-| **vue-app**     | [Sample Vue app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/blob/master/vue-app)                 |
+| folder          | Description                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| **angular-app** | [Sample Angular app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/tree/main/angular-app)             |
+| **api-starter** | [Sample Azure Functions app](https://github.com/MicrosoftDocs/mslearn-staticwebapp-api/tree/main/api-starter) |
+| **react-app**   | [Sample React app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/tree/main/react-app)                 |
+| **svelte-app**  | [Sample Svelte app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/tree/main/svelte-app)               |
+| **vue-app**     | [Sample Vue app](https://github.com/MicrosoftDocs/mslearn-staticwebapp/tree/main/vue-app)                     |
 
 ## Prerequisites
 


### PR DESCRIPTION
### Changes
- The links still contained the master branch, which is outdated and caused github to link to the default branch (main). Even though it's correct, it still showed the following warning message:

![Warning_message](https://user-images.githubusercontent.com/67599521/127751736-c0b83bf7-5bf7-4a80-ba4a-da2290769db2.png)

- The links contained "blob" which refers to files, but they should refer to directories (read on [stackoverflow](https://stackoverflow.com/questions/39400848/in-github-urls-what-is-the-difference-between-a-tree-and-a-blob)).

- The link to "api-starter" was broken, as discussed by others in this issue: #38 , so I updated it to link to the right directory in the [mslearn-staticwebapp-api](https://github.com/MicrosoftDocs/mslearn-staticwebapp-api/) repository.

### Additional Notes
- The "api-starter"-link now links to another repository which could be confusing