### PR TITLE
Change node engines to use version node v16

### DIFF
--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -2,7 +2,8 @@
   "name": "angular-app",
   "version": "0.0.0",
   "engines": {
-    "node": ">=12.14.0"
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
   }, 
   "scripts": {
     "ng": "ng",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
CI azure static web apps fails when try to build angular/react applications using a node version higher than node v16

Local error:
![image](https://github.com/MicrosoftDocs/mslearn-staticwebapp/assets/48362994/38a3bcb5-b0f0-497d-83ae-2cbcbe8bb8f0)

Github actions
![image](https://github.com/MicrosoftDocs/mslearn-staticwebapp/assets/48362994/4d25296d-0dde-4387-90a8-1131c32e753d)

I'll suggest forcing the node version to avoid issues when deploying the web app in the Azure portal

Switching between different versions and it works!
![image](https://github.com/MicrosoftDocs/mslearn-staticwebapp/assets/48362994/ed690a5c-955a-4d2b-b14c-2185f097c0b3)

![image](https://github.com/MicrosoftDocs/mslearn-staticwebapp/assets/48362994/fcb53c1e-45f3-4e5d-b111-c5b596048f05)
